### PR TITLE
Added import scale, fixed for 2018.1, and updated readme

### DIFF
--- a/Editor/SketchImportWindow.cs
+++ b/Editor/SketchImportWindow.cs
@@ -13,6 +13,7 @@ public class SketchImportWindow : EditorWindow
     //private members for parsing the json
     string jsonFileName = "layers.json";
     string importFolder = "";
+    float importScale = 1f;
 
     //private members for sprites and images
     string spriteAssetSubFolder = "sprites";
@@ -57,6 +58,10 @@ public class SketchImportWindow : EditorWindow
         {
             OnSelectButton();
         }
+
+        //SCALE
+        GUILayout.Label("Scale:", EditorStyles.boldLabel);
+        importScale = EditorGUILayout.FloatField(importScale, EditorStyles.objectField);
         
         //ROOT TRANSFORM
         GUILayout.Label("Root:", EditorStyles.boldLabel);
@@ -72,6 +77,7 @@ public class SketchImportWindow : EditorWindow
         if (GUILayout.Button("Import", GUILayout.Height(25)))
         {
             OnImportButton();
+            Debug.Log("Set import scale to " + importScale);
         }
         GUI.enabled = true;
     }
@@ -231,8 +237,8 @@ public class SketchImportWindow : EditorWindow
             return;
         }
 
-        float x = (float)jsonFrame["x"];
-        float y = (float)jsonFrame["y"];
+        float x = (float)jsonFrame["x"] * importScale;
+        float y = (float)jsonFrame["y"] * importScale;
 
         Vector2 globalPos = new Vector2(x, -y);
         Vector2 localPos = globalPos - parentPos; //TODO really needed? buggy for multiple artboards

--- a/Editor/SpriteImport.cs
+++ b/Editor/SpriteImport.cs
@@ -78,9 +78,8 @@ public class SpriteImport  {
 
         // Load a PNG or JPG image from disk to a Texture2D, assign this texture to a new sprite and return its reference
 
-        Sprite NewSprite = new Sprite();
         Texture2D SpriteTexture = LoadTexture(FilePath);
-        NewSprite = Sprite.Create(SpriteTexture, new Rect(0, 0, SpriteTexture.width, SpriteTexture.height), new Vector2(0, 0), PixelsPerUnit);
+        Sprite NewSprite = Sprite.Create(SpriteTexture, new Rect(0, 0, SpriteTexture.width, SpriteTexture.height), new Vector2(0, 0), PixelsPerUnit);
 
         return NewSprite;
     }

--- a/README.md
+++ b/README.md
@@ -4,21 +4,36 @@
 
 The SketchApp Import is a minimalistic plugin for Unity, bringing UI components and UI prototypes designed in Sketch into your Unity projects. 
 
-The plugin is currently based and dependent on the export files provided by Framer Classic, loading PNG assets as sprite images and position them according to your design.
+The plugin is currently based and dependent on the export files provided by either Framer Generator (free) or Framer Classic (trial/paid), loading PNG assets as sprite images and position them according to your design.
 
-(Framer Classic may also support exporting from Photshop and Flinto like Framer Generator did - that has not been looked into yet here. If so, then this plugin could also be used to import Photoshop and Flinto designs into Unity)
+Framer Generator (and perhaps Framer Classic too) supports exporting from Photshop and Flinto, soo this plugin can also be used to import Photoshop and Flinto designs into Unity.
 
 ## Usage
 
-(Import/usage instructions last updated 11/18/2019)
+(Import/usage instructions last updated 11/19/2019)
 
-### Export your design via Framer Classic's save function
+### Export your design via Framer Generator or via Framer Classic's save function
 
-If you never used the Sketch Framer workflow checkout some of guides on Medium like [Sketch Framer Bridge](https://blog.prototypr.io/build-the-bridge-between-sketch-and-framer-a3babf2cfa0f) and [Framer Sketch Workflow](https://medium.com/facebook-design/framer-sketch-an-intentional-workflow-f91ee2ee1cc1), especially on how to best prepare your design in Sketch for the export workflow. Most of it will also be true for later importing to Unity. 
+If you never used the Sketch Framer workflow checkout some of guides on Medium like [Sketch Framer Bridge](https://blog.prototypr.io/build-the-bridge-between-sketch-and-framer-a3babf2cfa0f) and [Framer Sketch Workflow](https://medium.com/facebook-design/framer-sketch-an-intentional-workflow-f91ee2ee1cc1), especially on how to best prepare your design in Sketch for the export workflow. Most of it will also be true for later importing to Unity. This primarily regards formatting and naming conventions for easier navigation in all platforms. 
 
-Open Framer Classic, navigate to the Code tab, and click Import in the bottom left (third option up from the bottom). Select the Sketch file from here that you saved in Sketch earlier - this is the most formal way to import from Sketch to Framer. Now choose File > Save to create the Framer file. Viewing that framer file's contents (in Mac by right click, Show Contents) will show a folder structure that includes the `imported` subfolder.
+#### Export from Framer Generator (free)
+1. Open Sketch with the relevant file open
+2. Open Framer Generator, and click Sketch > Import
+3. Check the location of the original .sketch file to now see an identically named .framer file next to it.
+4. Proceed to `Layers and Images Extraction from Framer File` section.
 
-From that exported framer file's contents (or folder), we are only interested in the `imported` subfolder, where you can find the `layers.json` and the `images` folder with all the PNG assets. You can put this folder in your Unity project if you would like - we will need to access that json file in a moment.
+#### Export from Framer Classic (trial/paid)
+1. Open Framer Classic, navigate to the Code tab, and click Import in the bottom left (third option up from the bottom)
+2. Select the Sketch file from here that you saved in Sketch earlier - this is the most formal way to import from Sketch to Framer
+3. Now choose File > Save to create the Framer file
+4. Proceed to `Layers and Images Extraction from Framer File` section.
+
+### Layers and Images Extraction from Framer File
+
+1. View that exported framer file's contents (in Mac by right click, Show Package Contents) to show a folder structure that includes the `imported` subfolder.
+2. Navigate into the `imported` subfolder, then into the `[appName@Resolution]` folder, eg. MyAppName@1x.
+3. Copy the `images` folder and `layers.json` file from here into somewhere directly accessible, like the Unity Assets folder.
+4. Proceed to Unity Import section.
 
 ### Import to Unity
 
@@ -32,4 +47,5 @@ From that exported framer file's contents (or folder), we are only interested in
 ## Dependencies
 
 * [Framer Generator](https://github.com/koenbok/Framer#set-up-framer-library) - for exporting from Sketch (osx only)
+* [Framer Classic](https://classic.framer.com/) - a paid alternative to Framer Generator
 * [Json.Net.Unity3D](https://github.com/SaladLab/Json.Net.Unity3D/releases) 9.0.1 - for parsing the json file provided by Framer Generator

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you never used the Sketch Framer workflow checkout some of guides on Medium l
 * Open the plugin via `Window/Sketch Import
 * Select the `layers.json` from your *Sketch Export* (inside the `imported` subfolder as mentioned above).
 * Select an UI component (like Canvas,Panel,...) inside your scene as the *Root* for your imported UI layers.
-** Note: Selecting Canvas allows you to use "Scale With Screen Size" as the UI scale mode, where the reference resolution can be adjusted so the Sketch file resolution matches the Unity resolution. 
+* Note: Selecting Canvas allows you to use "Scale With Screen Size" as the UI scale mode, where the reference resolution can be adjusted so the Sketch file resolution matches the Unity resolution. 
 
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -4,17 +4,21 @@
 
 The SketchApp Import is a minimalistic plugin for Unity, bringing UI components and UI prototypes designed in Sketch into your Unity projects. 
 
-The plugin is currently based and dependent on the export files provided by Framer Generator, loading PNG assets as sprite images and position them according to your design.
+The plugin is currently based and dependent on the export files provided by Framer Classic, loading PNG assets as sprite images and position them according to your design.
 
-As the Framer Generator also supports exporting from Photshop and Flinto the plugin can also be used to import Photoshop and Flinto designs into Unity
+(Framer Classic may also support exporting from Photshop and Flinto like Framer Generator did - that has not been looked into yet here. If so, then this plugin could also be used to import Photoshop and Flinto designs into Unity)
 
 ## Usage
 
-### Export your design via Framer Generator
+(Import/usage instructions last updated 11/18/2019)
+
+### Export your design via Framer Classic's save function
 
 If you never used the Sketch Framer workflow checkout some of guides on Medium like [Sketch Framer Bridge](https://blog.prototypr.io/build-the-bridge-between-sketch-and-framer-a3babf2cfa0f) and [Framer Sketch Workflow](https://medium.com/facebook-design/framer-sketch-an-intentional-workflow-f91ee2ee1cc1), especially on how to best prepare your design in Sketch for the export workflow. Most of it will also be true for later importing to Unity. 
 
-From the export folder we are only interested in the `imported` subfolder, where you can find the `layers.json` and the `images` folder with all the PNG assets.
+Open Framer Classic, navigate to the Code tab, and click Import in the bottom left (third option up from the bottom). Select the Sketch file from here that you saved in Sketch earlier - this is the most formal way to import from Sketch to Framer. Now choose File > Save to create the Framer file. Viewing that framer file's contents (in Mac by right click, Show Contents) will show a folder structure that includes the `imported` subfolder.
+
+From that exported framer file's contents (or folder), we are only interested in the `imported` subfolder, where you can find the `layers.json` and the `images` folder with all the PNG assets. You can put this folder in your Unity project if you would like - we will need to access that json file in a moment.
 
 ### Import to Unity
 
@@ -22,7 +26,7 @@ From the export folder we are only interested in the `imported` subfolder, where
 * Open the plugin via `Window/Sketch Import
 * Select the `layers.json` from your *Sketch Export* (inside the `imported` subfolder as mentioned above).
 * Select an UI component (like Canvas,Panel,...) inside your scene as the *Root* for your imported UI layers.
-* Select the Image Prefab from the Import Package Prefabs folder.
+** Note: Selecting Canvas allows you to use "Scale With Screen Size" as the UI scale mode, where the reference resolution can be adjusted so the Sketch file resolution matches the Unity resolution. 
 
 
 ## Dependencies


### PR DESCRIPTION
Now allows for 1x, 2x, 4x, etc scaled assets to be imported with correct positioning. Tweak to now run on 2018.1, with readme updated for how Framer and Framer Generator have changed since March 2018.